### PR TITLE
Add fallback autoloader for plugin bootstrap

### DIFF
--- a/binawebku-lms.php
+++ b/binawebku-lms.php
@@ -17,7 +17,28 @@ if (! defined('ABSPATH')) {
     exit;
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+// Load the Composer autoloader if it exists. Some distributions of the plugin
+// may not ship with the `vendor` directory (e.g. when installed directly from
+// source). In that case we fall back to a simple PSR-4 autoloader so the plugin
+// can still bootstrap without Composer.
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+} else {
+    spl_autoload_register(function ($class) {
+        $prefix = 'Binawebku\\LMS\\';
+        $len    = strlen($prefix);
+        if (0 !== strncmp($prefix, $class, $len)) {
+            return;
+        }
+
+        $relative = substr($class, $len);
+        $file     = __DIR__ . '/src/' . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    });
+}
 
 use Binawebku\LMS\Setup\Activator;
 use Binawebku\LMS\Setup\Deactivator;


### PR DESCRIPTION
## Summary
- avoid fatal error when `vendor/autoload.php` is missing
- bootstrap PSR-4 autoloader for plugin classes when Composer isn't used

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e3f7dacac8330b9e2988ceb722e29