### PR TITLE
Add admin dashboard submenus for LMS

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -18,9 +18,48 @@ class Admin {
             array($this, 'render'),
             'dashicons-welcome-learn-more'
         );
+
+        add_submenu_page(
+            'bwl-dashboard',
+            __('Students', 'binawebku-lms'),
+            __('Students', 'binawebku-lms'),
+            'manage_bwl',
+            'bwl-students',
+            array($this, 'render_students')
+        );
+
+        add_submenu_page(
+            'bwl-dashboard',
+            __('Teachers', 'binawebku-lms'),
+            __('Teachers', 'binawebku-lms'),
+            'manage_bwl',
+            'bwl-teachers',
+            array($this, 'render_teachers')
+        );
+
+        add_submenu_page(
+            'bwl-dashboard',
+            __('Settings', 'binawebku-lms'),
+            __('Settings', 'binawebku-lms'),
+            'manage_bwl',
+            'bwl-settings',
+            array($this, 'render_settings')
+        );
     }
 
     public function render() {
         echo '<div class="wrap"><h1>' . esc_html__('BinawebKu LMS', 'binawebku-lms') . '</h1></div>';
+    }
+
+    public function render_students() {
+        echo '<div class="wrap"><h1>' . esc_html__('Students', 'binawebku-lms') . '</h1></div>';
+    }
+
+    public function render_teachers() {
+        echo '<div class="wrap"><h1>' . esc_html__('Teachers', 'binawebku-lms') . '</h1></div>';
+    }
+
+    public function render_settings() {
+        echo '<div class="wrap"><h1>' . esc_html__('Settings', 'binawebku-lms') . '</h1></div>';
     }
 }


### PR DESCRIPTION
## Summary
- add Students, Teachers, and Settings subpages to LMS admin menu
- provide placeholder render methods for new admin pages

## Testing
- `phpunit` *(fails: command not found)*
- `composer global require phpunit/phpunit` *(fails: 403 CONNECT tunnel)*
- `phpcs --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e446dc99c8330b049cd980aaab2d8